### PR TITLE
Add Message.pack convenience method

### DIFF
--- a/examples/generated/proto/examplecom/casing_pb.d.ts
+++ b/examples/generated/proto/examplecom/casing_pb.d.ts
@@ -2,6 +2,7 @@
 // file: proto/examplecom/casing.proto
 
 import * as jspb from "google-protobuf";
+import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";
 
 export class CasingMessage extends jspb.Message {
   getTitlecase(): string;
@@ -20,6 +21,7 @@ export class CasingMessage extends jspb.Message {
   setLeadingunderscoretitlecase(value: string): void;
 
   serializeBinary(): Uint8Array;
+  pack(typeUrlPrefix?: string): google_protobuf_any_pb.Any;
   toObject(includeInstance?: boolean): CasingMessage.AsObject;
   static toObject(includeInstance: boolean, msg: CasingMessage): CasingMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/src/any-extension.ts
+++ b/src/any-extension.ts
@@ -1,0 +1,21 @@
+import { Message } from "google-protobuf";
+import { Any } from "google-protobuf/google/protobuf/any_pb";
+
+declare module "google-protobuf" {
+  interface Message {
+    pack(typeUrlPrefix?: string): Any;
+    toAny(typeUrlPrefix?: string): Any;
+  }
+}
+
+(Message.prototype as any).pack = function(this: Message, typeUrlPrefix?: string): Any {
+  const anyMsg = new Any();
+  const ctor: any = this.constructor;
+  const name: string = ctor.displayName || ctor.name;
+  anyMsg.pack(this.serializeBinary(), name, typeUrlPrefix);
+  return anyMsg;
+};
+
+(Message.prototype as any).toAny = function(this: Message, typeUrlPrefix?: string): Any {
+  return (this as any).pack(typeUrlPrefix);
+};

--- a/src/ts/fileDescriptorTSD.ts
+++ b/src/ts/fileDescriptorTSD.ts
@@ -20,6 +20,7 @@ export function printFileDescriptorTSD(fileDescriptor: FileDescriptorProto, expo
 
   printer.printEmptyLn();
   printer.printLn(`import * as jspb from "google-protobuf";`);
+  printer.printLn(`import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";`);
 
   fileDescriptor.getDependencyList().forEach((dependency: string) => {
     const pseudoNamespace = filePathToPseudoNamespace(dependency);

--- a/src/ts/message.ts
+++ b/src/ts/message.ts
@@ -22,6 +22,7 @@ import { printEnum } from "./enum";
 import { printOneOfDecl } from "./oneof";
 import { printExtension } from "./extensions";
 import JSType = FieldOptions.JSType;
+import * as google_protobuf_any_pb from "google-protobuf/google/protobuf/any_pb";
 
 function hasFieldPresence(field: FieldDescriptorProto, fileDescriptor: FileDescriptorProto): boolean {
   if (field.getLabel() === FieldDescriptorProto.Label.LABEL_REPEATED) {
@@ -232,6 +233,7 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
   });
 
   printer.printIndentedLn(`serializeBinary(): Uint8Array;`);
+  printer.printIndentedLn(`pack(typeUrlPrefix?: string): google_protobuf_any_pb.Any;`);
   printer.printIndentedLn(`toObject(includeInstance?: boolean): ${messageName}.${objectTypeName};`);
   printer.printIndentedLn(`static toObject(includeInstance: boolean, msg: ${messageName}): ${messageName}.${objectTypeName};`);
   printer.printIndentedLn(`static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};`);

--- a/test/integration/toAny.ts
+++ b/test/integration/toAny.ts
@@ -1,0 +1,12 @@
+import {assert} from "chai";
+import {CasingMessage} from "../../examples/generated/proto/examplecom/casing_pb";
+import {Any} from "google-protobuf/google/protobuf/any_pb";
+
+describe("toAny", () => {
+  it("should pack the message using pack()", () => {
+    const msg = new CasingMessage();
+    const packed = msg.pack();
+    assert.instanceOf(packed, Any);
+    assert.strictEqual(packed.getTypeUrl(), "type.googleapis.com/proto.examplecom.CasingMessage");
+  });
+});


### PR DESCRIPTION
## Summary
- extend `Message` prototype with `pack` and update `toAny`
- generate pack declaration for message types
- import Any type in generated files
- test packing messages into `Any`

## Testing
- `npm run lint`
- `npm test` *(fails: The gRPC binary module was not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686575518e3c8330bca772fdc6c2b0e3